### PR TITLE
chore: update examples to DSC 7.0.3 and UI 9.3.0

### DIFF
--- a/dataspace-connector/full/README.md
+++ b/dataspace-connector/full/README.md
@@ -26,8 +26,8 @@ This deployment example builds on the following compatible versions:
 
 | Component | Version |
 |:----------|:--------|
-| Dataspace Connector | 6.5.2 |
-| Dataspace Connector UI | 8.6.0 |
+| Dataspace Connector | 7.0.3 |
+| Dataspace Connector UI | 9.3.0 |
 | Portainer | 2.6.2 |
 | PostgreSQL | 13 |
 

--- a/dataspace-connector/full/dataspaceconnector/config/config.json
+++ b/dataspace-connector/full/dataspaceconnector/config/config.json
@@ -26,7 +26,7 @@
       "@value" : "IDS Connector with static example resources hosted by the Fraunhofer ISST",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
     } ],
-    "ids:version" : "6.5.2",
+    "ids:version" : "7.0.3",
     "ids:hasDefaultEndpoint" : {
       "@type" : "ids:ConnectorEndpoint",
       "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
@@ -34,8 +34,8 @@
         "@id" : "https://dataspaceconnector:8080/api/ids/data"
       }
     },
-    "ids:outboundModelVersion" : "4.2.6",
-    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6" ],
+    "ids:outboundModelVersion" : "4.2.7",
+    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7" ],
     "ids:title" : [ {
       "@value" : "Dataspace Connector",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"

--- a/dataspace-connector/full/docker-compose.yml
+++ b/dataspace-connector/full/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
 
   dataspaceconnector:
-    image: ghcr.io/international-data-spaces-association/dataspace-connector:6.5.2
+    image: ghcr.io/international-data-spaces-association/dataspace-connector:7.0.3
     container_name: dataspaceconnector
     ports:
       - 8080:8080
@@ -43,7 +43,7 @@ services:
     restart: always
 
   ui:
-    image: ghcr.io/international-data-spaces-association/dataspace-connector-ui:8.6.0
+    image: ghcr.io/international-data-spaces-association/dataspace-connector-ui:9.3.0
     container_name: ui
     ports:
       - 8083:8083

--- a/dataspace-connector/provider-consumer/config_consumer.json
+++ b/dataspace-connector/provider-consumer/config_consumer.json
@@ -26,7 +26,7 @@
       "@value" : "IDS Connector with static example resources hosted by the Fraunhofer ISST",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
     } ],
-    "ids:version" : "6.5.2",
+    "ids:version" : "7.0.3",
     "ids:hasDefaultEndpoint" : {
       "@type" : "ids:ConnectorEndpoint",
       "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
@@ -34,8 +34,8 @@
         "@id" : "http://consumer:8080/api/ids/data"
       }
     },
-    "ids:outboundModelVersion" : "4.2.6",
-    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6" ],
+    "ids:outboundModelVersion" : "4.2.7",
+    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7" ],
     "ids:title" : [ {
       "@value" : "Dataspace Connector",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"

--- a/dataspace-connector/provider-consumer/config_provider.json
+++ b/dataspace-connector/provider-consumer/config_provider.json
@@ -26,7 +26,7 @@
       "@value" : "IDS Connector with static example resources hosted by the Fraunhofer ISST",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
     } ],
-    "ids:version" : "6.5.2",
+    "ids:version" : "7.0.3",
     "ids:hasDefaultEndpoint" : {
       "@type" : "ids:ConnectorEndpoint",
       "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
@@ -34,8 +34,8 @@
         "@id" : "http://provider:8080/api/ids/data"
       }
     },
-    "ids:outboundModelVersion" : "4.2.6",
-    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6" ],
+    "ids:outboundModelVersion" : "4.2.7",
+    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7" ],
     "ids:title" : [ {
       "@value" : "Dataspace Connector",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"

--- a/dataspace-connector/provider-consumer/docker-compose.yml
+++ b/dataspace-connector/provider-consumer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
 
   provider:
-    image: ghcr.io/international-data-spaces-association/dataspace-connector:6.5.2
+    image: ghcr.io/international-data-spaces-association/dataspace-connector:7.0.3
     ports:
       - 8080:8080
     networks:
@@ -20,7 +20,7 @@ services:
     restart: always
 
   consumer:
-    image: ghcr.io/international-data-spaces-association/dataspace-connector:6.5.2
+    image: ghcr.io/international-data-spaces-association/dataspace-connector:7.0.3
     ports:
       - 8081:8080
     networks:

--- a/dataspace-connector/slim/docker/README.md
+++ b/dataspace-connector/slim/docker/README.md
@@ -25,7 +25,7 @@ This Dataspace Connector Deployment example consists of the following components
 
 | Component | Version |
 |:----------|:--------|
-| Dataspace Connector | latest |
+| Dataspace Connector | 7.0.3 |
 | PostgreSQL | 13 |
 
 ### Prerequisites

--- a/dataspace-connector/slim/docker/dataspaceconnector/config/config.json
+++ b/dataspace-connector/slim/docker/dataspaceconnector/config/config.json
@@ -26,7 +26,7 @@
       "@value" : "IDS Connector with static example resources hosted by the Fraunhofer ISST",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
     } ],
-    "ids:version" : "6.5.2",
+    "ids:version" : "7.0.3",
     "ids:hasDefaultEndpoint" : {
       "@type" : "ids:ConnectorEndpoint",
       "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
@@ -34,8 +34,8 @@
         "@id" : "https://localhost:8080/api/ids/data"
       }
     },
-    "ids:outboundModelVersion" : "4.2.6",
-    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6" ],
+    "ids:outboundModelVersion" : "4.2.7",
+    "ids:inboundModelVersion" : [ "4.0.0", "4.1.0", "4.1.2", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7" ],
     "ids:title" : [ {
       "@value" : "Dataspace Connector 🚀",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"

--- a/dataspace-connector/slim/docker/docker-compose.yml
+++ b/dataspace-connector/slim/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - dataspaceconnector-data:/var/lib/postgresql/data
 
   connector:
-    image: ghcr.io/international-data-spaces-association/dataspace-connector:6.5.2
+    image: ghcr.io/international-data-spaces-association/dataspace-connector:7.0.3
     container_name: 'dataspaceconnector'
     ports:
       - 8080:8080


### PR DESCRIPTION
Updates all DSC examples (`full`, `provider-consumer` and `slim`) to use DSC version `7.0.3`. Updates the UI version in the `full` example to `9.3.0`.